### PR TITLE
Autofix: Erase automated messages from activities

### DIFF
--- a/api/src/modules/activity/activity.service.ts
+++ b/api/src/modules/activity/activity.service.ts
@@ -223,12 +223,14 @@ export class ActivityService {
     this.newActivity(button.owner, payload, false);
   }
 
-  findByUserId(userId: string, locale: string) : Promise<ActivityDtoOut[]> {
-    
+  public findByUserId(userId: string, locale: string) : Promise<ActivityDtoOut[]> {
     return this.networkService.findButtonTypes()
     .then((buttonTypes) => {
       return this.activityRepository.find({
-        where: { owner: { id: userId } },
+        where: { 
+          owner: { id: userId },
+          eventName: Not('NewPost') // Exclude NewPost events
+        },
         relations: ['owner'],
         order: { created_at: 'DESC' },
       }).then((activities) => {


### PR DESCRIPTION
Modify the findByUserId method in ActivityService to exclude activities with eventName 'NewPost' 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    